### PR TITLE
Add helpers

### DIFF
--- a/develop/controllers/helpers/generateArticle.js
+++ b/develop/controllers/helpers/generateArticle.js
@@ -1,0 +1,45 @@
+const { Configuration, OpenAIApi } = require('openai');
+const fs = require('fs');
+require('dotenv').config();
+
+const configuration = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+const openai = new OpenAIApi(configuration);
+
+async function runCompletion(title, description, author) {
+  const response = await openai.createCompletion({
+    model: 'text-davinci-003',
+    prompt: `Can you rewrite this title <${title}> and this description <${description}> and write a blog post in the style of ${author}? And make up a blog post based on the title can description? Can you return it as a json with these fields; title, description, author, blogPost? Just a json response nothing else. an actual json file and no control characters`,
+    max_tokens: 2000,
+  });
+
+  const post = response.data.choices[0].text;
+  console.log(post);
+
+  try {
+    // const cleanText = post.replace(/[\x00-\x1F\x7F-\x9F]/g, '');
+    const jsonObject = JSON.parse(post); // put cleanText back here
+    console.log(jsonObject);
+
+    // Write the jsonObject to the "generated_article.json" file
+    fs.writeFile('generated_article.json', JSON.stringify(jsonObject, null, 2), (err) => {
+      if (err) {
+        console.error('Error writing file:', err);
+      } else {
+        console.log('JSON object written to generated_article.json');
+      }
+    });
+  } catch (error) {
+    console.error('Error parsing JSON:', error);
+  }
+
+  // Check the token count of the response
+  const tokenCount = response.data.usage.total_tokens;
+  console.log('Token count:', tokenCount);
+}
+
+module.exports = {
+  runCompletion,
+};

--- a/develop/controllers/helpers/newsRetriever.js
+++ b/develop/controllers/helpers/newsRetriever.js
@@ -1,0 +1,47 @@
+const dotenv = require('dotenv');
+const NewsAPI = require('newsapi');
+
+dotenv.config();
+const newsapi = new NewsAPI(process.env.NEWS_API_KEY);
+
+const categories = ['science', 'entertainment', 'health', 'sports', 'technology'];
+
+async function fetchNewsByCategories() {
+  const newsPromises = categories.map(async (category) => {
+    try {
+      const response = await newsapi.v2.topHeadlines({
+        category,
+        language: 'en',
+        sortBy: 'popularity',
+        country: 'us',
+      });
+
+      // Extracting and storing the required fields (including the category) for each article
+      return {
+        category,
+        articles: response.articles.map((article) => ({
+          title: article.title,
+          description: article.description,
+          urlToImage: article.urlToImage,
+        })),
+      };
+    } catch (error) {
+      console.error(`Error fetching news for category "${category}":`, error.message);
+      return {
+        category,
+        error: error.message,
+      };
+    }
+  });
+
+  const newHeadlines = await Promise.all(newsPromises);
+
+  return newHeadlines.reduce((acc, cur) => {
+    acc[cur.category] = cur.articles || { error: cur.error };
+    return acc;
+  }, {});
+}
+
+module.exports = {
+  fetchNewsByCategories,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "express-handlebars": "^7.1.0",
         "express-session": "^1.17.3",
         "mysql2": "^3.5.2",
+        "newsapi": "^2.4.1",
         "openai": "^3.3.0",
         "sequelize": "^6.32.1"
       },
@@ -696,6 +697,16 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/core-js": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.1.tgz",
+      "integrity": "sha512-2sKLtfq1eFST7l7v62zaqXacPc7uG8ZAya8ogijLhTtaKNcpzpB4TMoTw2Si+8GYKRwFPMMtUT0263QFWFfqyQ==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2561,6 +2572,15 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "node_modules/newsapi": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/newsapi/-/newsapi-2.4.1.tgz",
+      "integrity": "sha512-yw/aZBgDwNbNMqQ1V7XFKdW2jvL8Fh4qMiU0Awin87Rt6lbPnS8OuiLaL15Ws5X82/EXhzNf/djAlPHOWVgMJg==",
+      "dependencies": {
+        "core-js": "^3.6.5",
+        "node-fetch": "^2.6.0"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "5.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "express-handlebars": "^7.1.0",
         "express-session": "^1.17.3",
         "mysql2": "^3.5.2",
+        "openai": "^3.3.0",
         "sequelize": "^6.32.1"
       },
       "devDependencies": {
@@ -458,6 +459,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -468,6 +474,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/balanced-match": {
@@ -610,6 +624,17 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -721,6 +746,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -1414,6 +1447,25 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -1436,6 +1488,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -2645,6 +2710,15 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-3.3.0.tgz",
+      "integrity": "sha512-uqxI/Au+aPRnsaQRe8CojU0eCR7I0mBiKjD3sNMzY6DaC1ZVrc85u98mtJW6voDug8fgGN+DIZmTDxTthxb7dQ==",
+      "dependencies": {
+        "axios": "^0.26.0",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express-handlebars": "^7.1.0",
     "express-session": "^1.17.3",
     "mysql2": "^3.5.2",
+    "newsapi": "^2.4.1",
     "openai": "^3.3.0",
     "sequelize": "^6.32.1"
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express-handlebars": "^7.1.0",
     "express-session": "^1.17.3",
     "mysql2": "^3.5.2",
+    "openai": "^3.3.0",
     "sequelize": "^6.32.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds the OpenAI and News API Node Libraries and two scripts. One script retrieves the latest news for each category and returns a json. The other is the script that prompts Chat GPT for a new article based on three arguments (title, description, author)

I refactored everything to pass lint and tested the scripts